### PR TITLE
GUI patches

### DIFF
--- a/g3data/g3data-image.c
+++ b/g3data/g3data-image.c
@@ -135,7 +135,7 @@ void g3data_window_insert_image (G3dataWindow *window,
     gtk_box_pack_start (GTK_BOX (window->main_vbox), tophbox, FALSE, FALSE, 0);
 
     bottomhbox = gtk_hbox_new (FALSE, 0);
-    gtk_box_pack_start (GTK_BOX (window->main_vbox), bottomhbox, FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (window->main_vbox), bottomhbox, TRUE, TRUE, 0);
 
     bottomleftvbox = gtk_vbox_new (FALSE, 0);
     gtk_box_pack_start (GTK_BOX (bottomhbox), bottomleftvbox, FALSE, FALSE, 0);

--- a/g3data/g3data-window.c
+++ b/g3data/g3data-window.c
@@ -270,10 +270,11 @@ static void g3data_window_file_save_as (GtkAction *action, G3dataWindow *window)
 
     dialog = gtk_file_chooser_dialog_new ("Save As...",
                                           GTK_WINDOW (window),
-                                          GTK_FILE_CHOOSER_ACTION_OPEN,
+                                          GTK_FILE_CHOOSER_ACTION_SAVE,
                                           GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
                                           GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
                                           NULL);
+    gtk_file_chooser_set_current_name(dialog, "untitled.txt");
 
     if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT) {
         filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));

--- a/g3data/g3data-window.c
+++ b/g3data/g3data-window.c
@@ -274,7 +274,7 @@ static void g3data_window_file_save_as (GtkAction *action, G3dataWindow *window)
                                           GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
                                           GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
                                           NULL);
-    gtk_file_chooser_set_current_name(dialog, "untitled.txt");
+    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "untitled.txt");
 
     if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT) {
         filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));


### PR DESCRIPTION
1. Expand image properly (pack bottomhbox with fill=expand=TRUE).
In the old packing the image did not expand vertically.

2. Use correct action parameter in save_as dialog.
Use GTK_FILE_CHOOSER_ACTION_SAVE instead of GTK_FILE_CHOOSER_ACTION_OPEN, set default file name to "untitled.txt". With GTK_FILE_CHOOSER_ACTION_OPEN it was not possible to enter new file name with some GTK configurations.